### PR TITLE
Adding ghost/scattered light paper entry

### DIFF
--- a/static/des_components/des-other/des-paper-data.html
+++ b/static/des_components/des-other/des-paper-data.html
@@ -15,7 +15,7 @@
         <hr/>
       </div>
       <div class="card-content">
-        <strong><a href="https://arxiv.org/abs/1812.04004" target="_blank">Dark Energy Survey Year 1 results: Detection of Intra-cluster Light at Redshift ∼ 0.25</a> (Zhang Y., et al., 2018)</strong><br>
+        <strong><a href="https://arxiv.org/abs/1812.04004" target="_blank">Dark Energy Survey Year 1 results: Detection of Intra-cluster Light at Redshift ∼ 0.25</a> (Zhang et al., 2018)</strong><br>
         <br>
         Contact: <b>Yuan-Yuan Zhang</b> -- <a href="mailto:ynzhang@fnal.gov">ynzhang@fnal.gov</a></br>
         Data: Files can be obtained from <a href="http://desdr-server.ncsa.illinois.edu/despublic/other_files/paper-data/intra_cluster_light/" target="_blank"> here </a><br>
@@ -24,6 +24,16 @@
          clusters extending to 1 Mpc (proper distance), in the redshift range of 0.2 to 0.3, and extended DES g and r
          band PSF models to 10 arcmin. This page releases some of the measurements or modeled measurements.
         Readers interested in additional data products in the paper are encouraged to contact the authors.
+      </div>
+
+      <div class="card-content">
+        <strong><a href="https://arxiv.org/abs/2105.10524" target="_blank">A Machine Learning Approach to the Detection of Ghosting and Scattered Light Artifacts in Dark Energy Survey Images
+</a> (Chang et al., 2021)</strong><br>
+        <br>
+        Contact: <b>Michael Wang</b> </br>
+        Data: Files can be obtained from <a href="http://desdr-server.ncsa.illinois.edu/despublic/other_files/paper-data/ghosts_scattered_light/" target="_blank"> here </a><br>
+        Description: <br>
+        We develop a convolutional neural network model to detect ghosts and scattered light artifacts in DES images. This page provides the low resolution DECam focal plane images used for training, validating, and testing our network.
       </div>
       <hr/>
 


### PR DESCRIPTION
This is a test to add the ghost/scattered light CNN paper to the "Ancillary paper data" page.