### PR TITLE
Adding data products from the DES+KiDS joint cosmic shear analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Workflow for contributing content updates
     ```shell
     docker build -t desdm-public:dev .
     ```
+
+    or on MacOS:
+    ```shell
+    docker build --platform linux/x86_64 -t desdm-public:dev .
+    ```
+
 4. Configure the webserver to run in "dev" mode.
     ```shell
     docker run --rm --name desdm-public \
@@ -30,6 +36,9 @@ Workflow for contributing content updates
       desdm-public:dev \
       python3 vulcan.py --dev
     ```
+
+    again adding the flag ``--platform linux/x86_64`` on MacOS
+
 5. Run the webserver to serve the webpage.
     ```shell
     docker run --rm --name desdm-public \
@@ -41,6 +50,9 @@ Workflow for contributing content updates
       desdm-public:dev \
       python3 main.py
     ```
+
+    Once again adding the flag ``--platform linux/x86_64`` on MacOS
+
 6. Open your browser to http://127.0.0.1:8080 to view the website.
 7. Ensure that the ServiceWorker is not registered. Open your web browser's web development tools. In Firefox, use CTRL+SHIFT+I and go to the Application tab. Disable/remove any ServiceWorker you see listed.
 8. Edit and save the relevant HTML files. Reload the page and see the results. Repeat this step until satisfied.

--- a/static/des_components/des-public-main.html
+++ b/static/des_components/des-public-main.html
@@ -389,6 +389,11 @@
                   <a class="app-menu-item" id="needindent" name="gal-morphology" href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>
                 </div>
                 </app-submenu>
+           
+      <app-submenu no-auto-close>
+              <div class="app-menu-item" slot="submenu-trigger">
+                <a class="app-menu-item" id="needindent" name="Y3key-joint-des-kids" href="[[rootPath]]releases/y3a2/Y3key-joint-des-kids">DES Y3 + KiDS-1000</a>
+              </div> 
              
                   <!--app-submenu no-auto-close>
                 <div class="app-menu-item" slot="submenu-trigger">
@@ -678,6 +683,7 @@
                 <des-y3a2-massmaps name="Y3massmaps"></des-y3a2-massmaps >
               <des-y3a2-morphology name="gal-morphology"></des-y3a2-morphology>
               <des-y3a2-mard name="Y3mard"></des-y3a2-mard>
+              <des-y3a2-key-joint-des-kids name="Y3key-joint-des-kids"></des-y3a2-key-joint-des-kids >
 
 
           <!-- DR1 PAGES -->

--- a/static/des_components/des-y3a2/des-y3a2-key-joint-des-kids.html
+++ b/static/des_components/des-y3a2/des-y3a2-key-joint-des-kids.html
@@ -1,33 +1,32 @@
 <dom-module id="des-y3a2-key-joint-des-kids">
 
+
 <template>
 
-      <style include="shared-styles">
+      <style include="shared-styles"></style>
 
+<div class="fixup" id="kp_joint_des_kids_top"></div>
+<div class="fixdown"></div>
 
-</style>
-
-<div class="fixup" id="kp_joint-des-kids_top"></div>
-
-<des-card heading="DES Y3 + KiDS-1000">
+<des-card heading='DES Y3 + KiDS-1000'>
 	<ul>
-        <li><a href="javascript:void(0)" on-tap="_joint-des-kidskpoverview">Overview</a></li>
+        <li><a href="javascript:void(0)" on-tap="_joint_des_kidskpoverview">Overview</a></li>
         </ul>
 
 	<ul>
-      <li><a href="javascript:void(0)" on-tap="_joint-des-kidscosmochains">Cosmology Chains</a></li>
+      <li><a href="javascript:void(0)" on-tap="_joint_des_kidscosmochains">Cosmology Chains</a></li>
       </ul>
 
 	<ul>
-      <li><a href="javascript:void(0)" on-tap="_joint-des-kidslikelihood">Likelihood</a></li>
+      <li><a href="javascript:void(0)" on-tap="_joint_des_kidslikelihood">Likelihood</a></li>
       </ul>
 	
         <ul>
-      <li><a href="javascript:void(0)" on-tap="_joint-des-kidsdatavectors">Associated Data</a></li>
+      <li><a href="javascript:void(0)" on-tap="_joint_des_kidsdatavectors">Associated Data</a></li>
       </ul>
 
 
-<div id="keyjoint-des-kids_overview"></div>
+<div id="keyjoint_des_kids_overview"></div>
 <div class="card-content">
 
     <h2>
@@ -44,7 +43,7 @@
     </h2>
 
 
-    <div id="joint-des-kids_cosmochains"></div>
+    <div id="joint_des_kids_cosmochains"></div>
     <h3>Cosmology Chains <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
     <p>Download the cosmological chains presented in the DES Y3 + KiDS-1000 joint analysis. 
       Information about the adopted model and settings are documented in the file headers and 
@@ -111,7 +110,7 @@
       </tbody>
     </table>
 
-    <div id="joint-des-kids_likelihood"></div>
+    <div id="joint_des_kids_likelihood"></div>
       <h3>Likelihood <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
       <p>We analyze the two-point functions using a pipeline developed in <a href="https://cosmosis.readthedocs.io/en/latest/">CosmoSIS</a>.  
         The likelihood calculation for the combination of DES and KiDS can be accomplished using <a href = "https://github.com/joezuntz/cosmosis-standard-library/blob/main/examples/des-y3_and_kids-1000.ini">this file</a>.  
@@ -123,7 +122,7 @@
       see <a href="https://github.com/joezuntz/cosmosis-standard-library/tree/main/likelihood/des-y3_and_kids-1000/nofz_covariance">this 
         CosmoSIS directory</a> </p>
 
-	<div id="joint-des-kids_datavectors"></div>
+	<div id="joint_des_kids_datavectors"></div>
 
       <h3>Associated Data <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
 
@@ -457,16 +456,16 @@
 </template>
 
 <script>
-    class DesY3A2Keyjoint-des-kids extends Polymer.Element {
+    class DesY3A2Keyjoint_des_kids extends Polymer.Element {
       static get is() { return 'des-y3a2-key-joint-des-kids'; }
-        _top() {this.$.kp_joint-des-kids_top.scrollIntoView();}
-        _joint-des-kidskpoverview() {this.$.keyjoint-des-kids_overview.scrollIntoView();}
-        _joint-des-kidscosmochains() {this.$.joint-des-kids_cosmochains.scrollIntoView();}
-        _joint-des-kidsdatavectors() {this.$.joint-des-kids_datavectors.scrollIntoView();}
-        _joint-des-kidslikelihood() {this.$.joint-des-kids_likelihood.scrollIntoView();}
+        _top() {this.$.kp_joint_des_kids_top.scrollIntoView();}
+        _joint_des_kidskpoverview() {this.$.keyjoint_des_kids_overview.scrollIntoView();}
+        _joint_des_kidscosmochains() {this.$.joint_des_kids_cosmochains.scrollIntoView();}
+        _joint_des_kidsdatavectors() {this.$.joint_des_kids_datavectors.scrollIntoView();}
+        _joint_des_kidslikelihood() {this.$.joint_des_kids_likelihood.scrollIntoView();}
 
     }
-    window.customElements.define(DesY3A2Keyjoint-des-kids.is, DesY3A2Keyjoint-des-kids);
+    window.customElements.define(DesY3A2Keyjoint_des_kids.is, DesY3A2Keyjoint_des_kids);
   </script>
 
 </dom-module>

--- a/static/des_components/des-y3a2/des-y3a2-key-joint-des-kids.html
+++ b/static/des_components/des-y3a2/des-y3a2-key-joint-des-kids.html
@@ -1,0 +1,472 @@
+<dom-module id="des-y3a2-key-joint-des-kids">
+
+<template>
+
+      <style include="shared-styles">
+
+
+</style>
+
+<div class="fixup" id="kp_joint-des-kids_top"></div>
+
+<des-card heading="DES Y3 + KiDS-1000">
+	<ul>
+        <li><a href="javascript:void(0)" on-tap="_joint-des-kidskpoverview">Overview</a></li>
+        </ul>
+
+	<ul>
+      <li><a href="javascript:void(0)" on-tap="_joint-des-kidscosmochains">Cosmology Chains</a></li>
+      </ul>
+
+	<ul>
+      <li><a href="javascript:void(0)" on-tap="_joint-des-kidslikelihood">Likelihood</a></li>
+      </ul>
+	
+        <ul>
+      <li><a href="javascript:void(0)" on-tap="_joint-des-kidsdatavectors">Associated Data</a></li>
+      </ul>
+
+
+<div id="keyjoint-des-kids_overview"></div>
+<div class="card-content">
+
+    <h2>
+      <strong>Overview</strong>
+    </h2>
+    <p>In <a href="https://arxiv.org/abs/2305.17173">Dark Energy Survey and Kilo-Degree Survey 
+      Collaboration (2023)</a> we present a joint cosmic shear analysis of the Dark Energy Survey (DES Y3) and the 
+      Kilo-Degree Survey (<a href="https://kids.strw.leidenuniv.nl/DR4/lensing.php"></a>KiDS-1000</a>) in a collaborative 
+      effort between the two survey teams. We use a Hybrid analysis pipeline, defined from a mock survey study quantifying the 
+      impact of the different analysis choices originally adopted by each survey team.
+
+    <h2>
+      <strong>Description</strong>
+    </h2>
+
+
+    <div id="joint-des-kids_cosmochains"></div>
+    <h3>Cosmology Chains <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
+    <p>Download the cosmological chains presented in the DES Y3 + KiDS-1000 joint analysis. 
+      Information about the adopted model and settings are documented in the file headers and 
+      summarised in Table 2 of <a href="https://arxiv.org/abs/2305.17173">Dark Energy Survey and Kilo-Degree Survey 
+      Collaboration (2023)</a>
+      
+    When using the chains, the contribution of each sample must be weighted using the weight column. 
+    The final N samples to be used are listed at the very end of the chain (nsample), along with the final log evidence. 
+    Note that this chain used the Polychord nested sampler, so the sequence of samples is not a random walk.</p>
+
+    <table>
+      <colgroup>
+        <col />
+        <col />
+      </colgroup>
+
+      <tbody>
+
+
+        <tr>
+          <th>
+            <p>LCDM</p>
+          </th>
+          <th>File Name</th>
+        </tr>
+
+
+        <tr>
+	<td colspan="1">
+            <p>Joint DES Y3 + KiDS-1000 cosmic shear</p>
+          </td>
+
+          <td colspan="1">
+            <p>
+              <a href="https://desdr-server.ncsa.illinois.edu/despublic/y3a2_files/y3a2_joint-des-kids/chains/chain_desy3_and_kids1000_hybrid_analysis.txt">chain_desy3_and_kids1000_hybrid_analysis.txt</a>
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+	<td colspan="1">
+            <p>Hybrid pipeline re-analysis of DES Y3 cosmic shear</p>
+          </td>
+
+          <td colspan="1">
+            <p>
+              <a href="https://desdr-server.ncsa.illinois.edu/despublic/y3a2_files/y3a2_joint-des-kids/chains/chain_desy3_hybrid_analysis.txt">chain_desy3_hybrid_analysis.txt</a>
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+	<td colspan="1">
+            <p>Hybrid pipeline re-analysis of KiDS-1000 cosmic shear</p>
+          </td>
+
+          <td colspan="1">
+            <p>
+              <a href="https://desdr-server.ncsa.illinois.edu/despublic/y3a2_files/y3a2_joint-des-kids/chains/chain_kids1000_hybrid_analysis.txt">chain_kids1000_hybrid_analysis.txt</a>
+            </p>
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+
+    <div id="joint-des-kids_likelihood"></div>
+      <h3>Likelihood <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
+      <p>We analyze the two-point functions using a pipeline developed in <a href="https://cosmosis.readthedocs.io/en/latest/">CosmoSIS</a>.  
+        The likelihood calculation for the combination of DES and KiDS can be accomplished using <a href = "https://github.com/joezuntz/cosmosis-standard-library/blob/main/examples/des-y3_and_kids-1000.ini">this file</a>.  
+        Note that due to minor updates in CosmoSIS, this calculation differs very slightly from the original version presented in
+        <a href="https://arxiv.org/abs/2305.17173">Dark Energy Survey and Kilo-Degree Survey 
+          Collaboration (2023)</a>, but we have verified that there is no noticeable impact on the cosmological constraints.</p>
+
+     <p> If you wish to analyse KiDS-1000 using correlated priors for the redshift nuisance parameters, 
+      see <a href="https://github.com/joezuntz/cosmosis-standard-library/tree/main/likelihood/des-y3_and_kids-1000/nofz_covariance">this 
+        CosmoSIS directory</a> </p>
+
+	<div id="joint-des-kids_datavectors"></div>
+
+      <h3>Associated Data <a style="font-size:0.72rem" href="javascript:void(0)" on-tap="_top">(Top)</a></h3>
+
+      <p>This fits table includes: the DES Y3 two-point correlation functions measured from a slightly reduced footprint to remove
+        areal overlap with KiDS-1000 (see <a href="https://arxiv.org/abs/2305.17173">Appendix A</a> for details); the KiDS-1000 
+        COSEBIs E-modes; redshift distributions; analytical covariance matrices.   Note that we assume DES Y3 and KiDS-1000 are independent. 
+        There are the following 6 HDU extensions in the FITS binary file. 
+      <ul>
+      <li><a href="https://desdr-server.ncsa.illinois.edu/despublic/y3a2_files/y3a2_joint-des-kids/assoc_data/DES-Y3_xipm_and_KiDS-1000_COSEBIs_2.0_300.0.fits">DES-Y3_xipm_and_KiDS-1000_COSEBIs_2.0_300.0.fits</a></li>
+      </ul>
+
+  <table class="wrapped">
+        <colgroup>
+          <col/>
+          <col/>
+          <col/>
+        </colgroup>
+        <tbody>
+          <tr>
+            <th colspan="3">
+              <p>BinTableHDU 1 and 2:  Name = nz_source_kids/nz_source_des</p>
+              <p>(Tomographic redshift distribution of the source galaxies)</p>
+            </th>
+          </tr>
+          <tr>
+            <td colspan="1">
+              <strong>
+                <strong>Header Value</strong>
+              </strong>
+            </td>
+            <td colspan="1">
+              <strong>Description</strong>
+            </td>
+          </tr>
+          <tr>
+            <td>NGAL_{i}</td>
+            <td>
+              <p>The mean number density (gal/arcmin^2) of the tomographic bin (1-5, KiDS) or (1-4, DES)</p>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="1">SIG_E_{i}</td>
+            <td colspan="1">The total ellipticity dispersion of the tomographic bin (1-5, KiDS) or (1-4, DES)</td>
+          </tr>
+          <tr>
+            <td colspan="1">
+              <strong>Column Name</strong>
+            </td>
+            <td colspan="1">
+              <strong>Description</strong>
+            </td>
+          </tr>
+          <tr>
+            <td>Z_LOW</td>
+            <td>The lower z boundary of this z bin range</td>
+          </tr>
+          <tr>
+            <td>Z_MID</td>
+            <td>The central z <span>of this z bin range</span>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="1">Z_HIGH</td>
+            <td colspan="1">The upper z boundary <span>of this z bin range</span>
+            </td>
+          </tr>
+          <tr>
+      <td colspan="1">BIN{i}</td>
+            <td colspan="1">The n(z) in this z bin range for tomographic bin (1-5, KiDS) or (1-4, DES)</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="auto-cursor-target">
+        <br/>
+      </p>   
+
+    <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+    <table class="wrapped">
+      <colgroup>
+        <col/>
+        <col/>
+        <col/>
+      </colgroup>
+      <tbody>
+        <tr>
+          <th colspan="3">
+            <p>BinTableHDU 3:  Name = En</p>
+            <p>(KiDS-1000 Cosmic shear E<span>n</span>
+              <span> COSEBIs</span>)</p>
+          </th>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>
+              <strong>Header Value</strong>
+            </strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>KERNEL_1</td>
+          <td>
+            <p>The HDU name of the corresponding first (source) redshift distribution</p>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">KERNEL_2</td>
+          <td colspan="1">
+            <span>The HDU name of the corresponding second (source) redshift distribution</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ZBIN_1</td>
+          <td colspan="1">The number of <span>first (source) tomographic bins</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ZBIN_2</td>
+          <td colspan="1">
+            <span>The number of second</span>
+            <span> (source) tomographic bins</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ANG</td>
+          <td colspan="1">The number of COSEBIs modes</td>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>Column Name</strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>BIN1</td>
+          <td>Index of first (source) redshift bin</td>
+        </tr>
+        <tr>
+          <td>BIN2</td>
+          <td>
+            <span>Index of second (source) redshift bin</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">ANGBIN</td>
+          <td colspan="1">Index of the COSEBIs mode</td>
+        </tr>
+        <tr>
+          <td colspan="1">VALUE</td>
+          <td colspan="1">
+            <span>Measured value</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">ANG</td>
+          <td colspan="1">Index of the COSEBIs mode</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="auto-cursor-target">
+      <br/>
+    </p>
+
+    <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+
+    <table class="wrapped">
+      <colgroup>
+        <col/>
+        <col/>
+        <col/>
+      </colgroup>
+      <tbody>
+        <tr>
+          <th colspan="3">
+            <p>BinTableHDU 4 and 5:  Name = xip and xim</p>
+            <p>(Cosmic shear xi<span>+/-</span>
+              <span> two-point shear correlation function</span>)</p>
+          </th>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>
+              <strong>Header Value</strong>
+            </strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>KERNEL_1</td>
+          <td>
+            <p>The HDU name of the corresponding first (source) redshift distribution</p>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">KERNEL_2</td>
+          <td colspan="1">
+            <span>The HDU name of the corresponding second (source) redshift distribution</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ZBIN_1</td>
+          <td colspan="1">The number of <span>first (source) tomographic bins</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ZBIN_2</td>
+          <td colspan="1">
+            <span>The number of second</span>
+            <span> (source) tomographic bins</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">N_ANG</td>
+          <td colspan="1">The number of angular bins</td>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>Column Name</strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>BIN1</td>
+          <td>Index of first (source) redshift bin</td>
+        </tr>
+        <tr>
+          <td>BIN2</td>
+          <td>
+            <span>Index of second (source) redshift bin</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">ANGBIN</td>
+          <td colspan="1">Index of the angular bin</td>
+        </tr>
+	<tr>
+          <td colspan="1">ANGMIN</td>
+          <td colspan="1">The lower angular bin edge [arcmin]</td>
+        </tr>
+	<tr>
+          <td colspan="1">ANGMAX</td>
+          <td colspan="1">The upper angular bin edge [arcmin]</td>
+        </tr>
+
+        <tr>
+          <td colspan="1">VALUE</td>
+          <td colspan="1">
+            <span>Measured value</span>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">ANG</td>
+          <td colspan="1">Mean angular separation [arcmin]</td>
+        </tr>
+        <tr>
+          <td colspan="1">NPAIRS</td>
+          <td colspan="1">Number of galaxy pairs in the bin</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="auto-cursor-target">
+      <br/>
+    </p>
+
+    <!--%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%-->
+
+   <table class="wrapped">
+      <colgroup>
+        <col/>
+        <col/>
+        <col/>
+      </colgroup>
+      <tbody>
+        <tr>
+          <th colspan="3">
+            <p>ImageHDU = 1: Name = COVMAT</p>
+            <p>(Covariance matrix)</p>
+          </th>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>Image HDU</strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>Image array</td>
+          <td>
+            <p>475x475 array of covariance matrix </p>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="1">
+            <strong>Header Value</strong>
+          </td>
+          <td colspan="1">
+            <strong>Description</strong>
+          </td>
+        </tr>
+        <tr>
+          <td>NAME_{i} (in header)</td>
+          <td>The order of the covariance blocks (0-2), corresponding to the names of other HDUs that hold the data vector</td>
+        </tr>
+        <tr>
+          <td>STRT_{i} (in header)</td>
+          <td>The start index of each covariance block (0-2)</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="auto-cursor-target">
+      <br/>
+    </p>
+
+      </tbody>
+    </table>
+
+
+
+</div>
+</des-card>
+</template>
+
+<script>
+    class DesY3A2Keyjoint-des-kids extends Polymer.Element {
+      static get is() { return 'des-y3a2-key-joint-des-kids'; }
+        _top() {this.$.kp_joint-des-kids_top.scrollIntoView();}
+        _joint-des-kidskpoverview() {this.$.keyjoint-des-kids_overview.scrollIntoView();}
+        _joint-des-kidscosmochains() {this.$.joint-des-kids_cosmochains.scrollIntoView();}
+        _joint-des-kidsdatavectors() {this.$.joint-des-kids_datavectors.scrollIntoView();}
+        _joint-des-kidslikelihood() {this.$.joint-des-kids_likelihood.scrollIntoView();}
+
+    }
+    window.customElements.define(DesY3A2Keyjoint-des-kids.is, DesY3A2Keyjoint-des-kids);
+  </script>
+
+</dom-module>

--- a/static/des_components/des-y3a2/des-y3a2.html
+++ b/static/des_components/des-y3a2/des-y3a2.html
@@ -11,7 +11,7 @@
             </div>
       <div class="card-content">
           <span>
-              This page presents the release of the DES Year 3 (Y3) data products used for cosmology analyses, which includes additional information with respect to DR1, and provides the necessary information to reproduce and reanalyze this data set. For a detailed description and list of available files of this release please see the links below. Users may also consider using the <a href="[[rootPath]]releases/dr2">DES DR2</a> based on six years of survey operations. 
+            This page presents the release of the DES Year 3 (Y3) data products used for cosmology analyses, which includes additional information with respect to DR1, and provides the necessary information to reproduce and reanalyze this data set. For a detailed description and list of available files of this release please see the links below. Users may also consider using the <a href="[[rootPath]]releases/dr2">DES DR2</a> based on six years of survey operations. 
 
 	      <p> Gold products and Deep Fields catalogs are accessible through a query server, they can be accessed from <a href="https://des.ncsa.illinois.edu/desaccess/" target="_blank">DESaccess</a>. The Y3 Gold catalog is also accessible from the <a href="https://cosmohub.pic.es">CosmoHub website</a>.</p>
 	      
@@ -21,7 +21,7 @@
         <strong>Release Notes:</strong>
       </p>
 
-      <p><u>10 September 2023 </u>: Joint re-analysis of DES Y3 and KiDS-1000 cosmic shear.  Data vectors and chains in <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">Y3KP DES+KiDS</a>.</p>
+      <p><u>10 September 2023 </u>: Joint re-analysis of DES Y3 and KiDS-1000 cosmic shear.  Data vectors and chains in <a href="[[rootPath]]releases/y3a2/Y3key-joint-des-kids">Y3KP DES+KiDS</a>.</p>
       <p><u>10 April 2023 </u>: Release of Y3KP 6x2pt data vectors and chains in <a href="[[rootPath]]releases/y3a2/Y3key-cmblens">Y3KP+CMB lensing</a>.</p>
       <p><u>3 July 2022</u>: Release of Y3KP extended cosmology likelihoods in <a href="[[rootPath]]releases/y3a2/Y3key-extensions">Y3KP Beyond-L/wCDM</a>.</p>
       <p><u>3 March 2022</u>: Release of Y3KP data vectors in <a href="[[rootPath]]releases/y3a2/Y3key-products">Y3KP Products</a>.</p>
@@ -52,7 +52,7 @@
       <p style="margin-left: 60.0px;">11) <a href="[[rootPath]]releases/y3a2/Y3massmaps">WL Mass Maps</a>: Mass maps reconstructed from weak lensing signal</p>
       <p style="margin-left: 60.0px;">12) <a href="[[rootPath]]releases/y3a2/Y3mard">X-ray Clusters</a>: X-ray selected galaxy clusters</p>
       <p style="margin-left: 60.0px;">13) <a href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>: A Neural Network galaxy morphology catalog</p>      
-      <p style="margin-left: 60.0px;">14) <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">DES Y3 + KiDS-1000</a>: A joint cosmic shear re-analysis
+      <p style="margin-left: 60.0px;">14) <a href="[[rootPath]]releases/y3a2/Y3key-joint-des-kids">DES Y3 + KiDS-1000</a>: A joint cosmic shear re-analysis
         <span style="color: rgb(255,0,0);"> </span>
       </p>
       <p style="text-align: left;">

--- a/static/des_components/des-y3a2/des-y3a2.html
+++ b/static/des_components/des-y3a2/des-y3a2.html
@@ -20,6 +20,8 @@
       <p>
         <strong>Release Notes:</strong>
       </p>
+
+      <p><u>10 September 2023 </u>: Joint re-analysis of DES Y3 and KiDS-1000 cosmic shear.  Data vectors and chains in <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">Y3KP DES+KiDS</a>.</p>
       <p><u>10 April 2023 </u>: Release of Y3KP 6x2pt data vectors and chains in <a href="[[rootPath]]releases/y3a2/Y3key-cmblens">Y3KP+CMB lensing</a>.</p>
       <p><u>3 July 2022</u>: Release of Y3KP extended cosmology likelihoods in <a href="[[rootPath]]releases/y3a2/Y3key-extensions">Y3KP Beyond-L/wCDM</a>.</p>
       <p><u>3 March 2022</u>: Release of Y3KP data vectors in <a href="[[rootPath]]releases/y3a2/Y3key-products">Y3KP Products</a>.</p>
@@ -49,7 +51,8 @@
       <p style="margin-left: 60.0px;">9) <a href="[[rootPath]]releases/y3a2/Y3redmagic">redMaGiC Catalogs</a>: Y3 redMaGiC galaxy catalogs</p>
       <p style="margin-left: 60.0px;">10) <a href="[[rootPath]]releases/y3a2/Y3massmaps">WL Mass Maps</a>: Mass maps reconstructed from weak lensing signal</p>
       <p style="margin-left: 60.0px;">11) <a href="[[rootPath]]releases/y3a2/Y3mard">X-ray Clusters</a>: X-ray selected galaxy clusters</p>
-      <p style="margin-left: 60.0px;">12) <a href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>: A Neural Network galaxy morphology catalog
+      <p style="margin-left: 60.0px;">12) <a href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>: A Neural Network galaxy morphology catalog</p>      
+      <p style="margin-left: 60.0px;">13) <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">DES Y3 + KiDS-1000</a>: A joint cosmic shear re-analysis
         <span style="color: rgb(255,0,0);"> </span>
       </p>
       <p style="text-align: left;">
@@ -112,7 +115,7 @@
     <p>For a full list of Year-3 publications, please visit <a href="https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers">https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers/</a></p>
 
     <p>
-      <a href="https://arxiv.org/abs/2105.13549">https://arxiv.org/abs/2105.13549</a> Dark Energy Survey Year 3 Results: Cosmological Constraints from Galaxy Clustering and Weak Lensing, DES Collaboration, arXiv e-prints, arXiv:2105.13549 (2021)</p>
+      <a href="https://arxiv.org/abs/2305.17173">https://arxiv.org/abs/2305.17173</a> DES Y3 + KiDS-1000: Consistent cosmology combining cosmic shear surveys, Dark Energy Survey and Kilo-Degree Survey Collaboration, arXiv e-prints, arXiv:2305.17173 (2023)</p>
     <p>
       <a href="https://arxiv.org/abs/2011.03407">https://arxiv.org/abs/2011.03407</a> Dark Energy Survey Year 3 Results: Photometric Data Set for Cosmology, Sevilla-Noarbe, I., Bechtol, K., Carrasco Kind, M., et al. (DES Collaboration), ApJS, 254, 24 (2021)</p>
     <p>

--- a/static/des_components/des-y3a2/des-y3a2.html
+++ b/static/des_components/des-y3a2/des-y3a2.html
@@ -46,13 +46,13 @@
       <p style="margin-left: 60.0px;">5) <a href="[[rootPath]]releases/y3a2/Y3key-catalogs">Y3KP Catalogs</a>: This section contains all catalogs used to run the main cosmological analysis from the cross-correlation of weak-lensing and clustering. It is serve as several h5 files, plus some code snippet (python) to interface with the data and isntructions to reproduce the catalogs used in our analysis</p>
       <p style="margin-left: 60.0px;">6) <a href="[[rootPath]]releases/y3a2/Y3key-products">Y3KP Products</a>: Data vectors and likelihoods from the main DES cosmological analysis (3x2pt statistics), combining weak lensing and galaxy clustering. These results used the Y3KP Catalogs described above.</p>
       <p style="margin-left: 60.0px;">7) <a href="[[rootPath]]releases/y3a2/Y3key-extensions">Y3KP Beyond-L/wCDM</a>: Likelihoods from DES Y3 3x2pt Extensions KP analysis (3x2pt statistics). These results used the Y3KP Catalogs described above.</p>
-      <p style="margin-left: 60.0px;">7) <a href="[[rootPath]]releases/y3a2/Y3key-cmblens">Y3KP+CMB lensing</a>: Likelihoods from DES Y3 analysis including CMB lensing (6x2pt statistics). These results used the Y3KP Catalogs described above.</p>
-      <p style="margin-left: 60.0px;">8) <a href="[[rootPath]]releases/y3a2/Y3bao">BAO Sample</a>: a subset of Gold products aimed at measuring the BAO scale; includes the catalogs, data vectors and likelihoods. The selection was based on the Y3 Gold catalog.</p>
-      <p style="margin-left: 60.0px;">9) <a href="[[rootPath]]releases/y3a2/Y3redmagic">redMaGiC Catalogs</a>: Y3 redMaGiC galaxy catalogs</p>
-      <p style="margin-left: 60.0px;">10) <a href="[[rootPath]]releases/y3a2/Y3massmaps">WL Mass Maps</a>: Mass maps reconstructed from weak lensing signal</p>
-      <p style="margin-left: 60.0px;">11) <a href="[[rootPath]]releases/y3a2/Y3mard">X-ray Clusters</a>: X-ray selected galaxy clusters</p>
-      <p style="margin-left: 60.0px;">12) <a href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>: A Neural Network galaxy morphology catalog</p>      
-      <p style="margin-left: 60.0px;">13) <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">DES Y3 + KiDS-1000</a>: A joint cosmic shear re-analysis
+      <p style="margin-left: 60.0px;">8) <a href="[[rootPath]]releases/y3a2/Y3key-cmblens">Y3KP+CMB lensing</a>: Likelihoods from DES Y3 analysis including CMB lensing (6x2pt statistics). These results used the Y3KP Catalogs described above.</p>
+      <p style="margin-left: 60.0px;">9) <a href="[[rootPath]]releases/y3a2/Y3bao">BAO Sample</a>: a subset of Gold products aimed at measuring the BAO scale; includes the catalogs, data vectors and likelihoods. The selection was based on the Y3 Gold catalog.</p>
+      <p style="margin-left: 60.0px;">10) <a href="[[rootPath]]releases/y3a2/Y3redmagic">redMaGiC Catalogs</a>: Y3 redMaGiC galaxy catalogs</p>
+      <p style="margin-left: 60.0px;">11) <a href="[[rootPath]]releases/y3a2/Y3massmaps">WL Mass Maps</a>: Mass maps reconstructed from weak lensing signal</p>
+      <p style="margin-left: 60.0px;">12) <a href="[[rootPath]]releases/y3a2/Y3mard">X-ray Clusters</a>: X-ray selected galaxy clusters</p>
+      <p style="margin-left: 60.0px;">13) <a href="[[rootPath]]releases/y3a2/gal-morphology">Galaxy Morphology</a>: A Neural Network galaxy morphology catalog</p>      
+      <p style="margin-left: 60.0px;">14) <a href="[[rootPath]]releases/y3a2/Y3key-DES_and_KiDS">DES Y3 + KiDS-1000</a>: A joint cosmic shear re-analysis
         <span style="color: rgb(255,0,0);"> </span>
       </p>
       <p style="text-align: left;">

--- a/static/des_components/des-y3a2/des-y3a2.html
+++ b/static/des_components/des-y3a2/des-y3a2.html
@@ -11,7 +11,7 @@
             </div>
       <div class="card-content">
           <span>
-            This page presents the release of the DES Year 3 (Y3) data products used for cosmology analyses, which includes additional information with respect to DR1, and provides the necessary information to reproduce and reanalyze this data set. For a detailed description and list of available files of this release please see the links below. Users may also consider using the <a href="[[rootPath]]releases/dr2">DES DR2</a> based on six years of survey operations. 
+              This page presents the release of the DES Year 3 (Y3) data products used for cosmology analyses, which includes additional information with respect to DR1, and provides the necessary information to reproduce and reanalyze this data set. For a detailed description and list of available files of this release please see the links below. Users may also consider using the <a href="[[rootPath]]releases/dr2">DES DR2</a> based on six years of survey operations. 
 
 	      <p> Gold products and Deep Fields catalogs are accessible through a query server, they can be accessed from <a href="https://des.ncsa.illinois.edu/desaccess/" target="_blank">DESaccess</a>. The Y3 Gold catalog is also accessible from the <a href="https://cosmohub.pic.es">CosmoHub website</a>.</p>
 	      
@@ -114,6 +114,8 @@
     </h2>
     <p>For a full list of Year-3 publications, please visit <a href="https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers">https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers/</a></p>
 
+    <p>
+      <a href="https://arxiv.org/abs/2105.13549">https://arxiv.org/abs/2105.13549</a> Dark Energy Survey Year 3 Results: Cosmological Constraints from Galaxy Clustering and Weak Lensing, DES Collaboration, arXiv e-prints, arXiv:2105.13549 (2021)</p>
     <p>
       <a href="https://arxiv.org/abs/2011.03407">https://arxiv.org/abs/2011.03407</a> Dark Energy Survey Year 3 Results: Photometric Data Set for Cosmology, Sevilla-Noarbe, I., Bechtol, K., Carrasco Kind, M., et al. (DES Collaboration), ApJS, 254, 24 (2021)</p>
     <p>

--- a/static/des_components/des-y3a2/des-y3a2.html
+++ b/static/des_components/des-y3a2/des-y3a2.html
@@ -115,8 +115,6 @@
     <p>For a full list of Year-3 publications, please visit <a href="https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers">https://www.darkenergysurvey.org/des-year-3-cosmology-results-papers/</a></p>
 
     <p>
-      <a href="https://arxiv.org/abs/2305.17173">https://arxiv.org/abs/2305.17173</a> DES Y3 + KiDS-1000: Consistent cosmology combining cosmic shear surveys, Dark Energy Survey and Kilo-Degree Survey Collaboration, arXiv e-prints, arXiv:2305.17173 (2023)</p>
-    <p>
       <a href="https://arxiv.org/abs/2011.03407">https://arxiv.org/abs/2011.03407</a> Dark Energy Survey Year 3 Results: Photometric Data Set for Cosmology, Sevilla-Noarbe, I., Bechtol, K., Carrasco Kind, M., et al. (DES Collaboration), ApJS, 254, 24 (2021)</p>
     <p>
       <a href="https://arxiv.org/abs/2012.12825">https://arxiv.org/abs/2012.12825</a> Dark Energy Survey Year 3 Results: Measuring the Survey Transfer Function with Balrog, Everett, S., et al. (DES Collaboration), arXiv e-prints, arXiv:2012.12825 (2020)</p>

--- a/static/des_components/elements.html
+++ b/static/des_components/elements.html
@@ -118,6 +118,7 @@
 <link rel="import" href="des-y3a2/des-y3a2-key-catalogs.html" >
 <link rel="import" href="des-y3a2/des-y3a2-morphology.html">
 <link rel="import" href="des-y3a2/des-y3a2-psf.html" >
+<link rel="import" href="des-y3a2/des-y3a2-key-joint-des-kids.html" >
 
 <!-- DES DR1 -->
 <link rel="import" href="des-dr1/des-dr1.html">


### PR DESCRIPTION
This fork includes:

1) des-y3a2/des-y3a2-key-joint-des-kids.html 
A new webpage covering chains and likelihoods for the DES+KiDS re-analysis

2) Updates to the release notes in des-y3a2.html

3) Updates to des-public_main.html and elements.html to add the page to the banner

4) Updated readme to include the additional flag needed when building the repo on M1 Mac.

Note we still have to update the data files on the DES server - so those links will currently go 404